### PR TITLE
feat: unify code paths for the `retry` and `no_retry` paths

### DIFF
--- a/src/waitz.rs
+++ b/src/waitz.rs
@@ -17,12 +17,7 @@ impl Waitz<'_> {
     pub fn run(&self) {
         self.logger.debug(&format!("{:?}", &self));
 
-        if self.no_retry {
-            is_successful(self.command, &self.args, &self.logger);
-            return;
-        }
-
-        while !is_successful(self.command, &self.args, &self.logger) {
+        while !is_successful(self.command, &self.args, &self.logger) && !self.no_retry {
             self.logger.verbose(&format!(
                 "Wait for {:?} milliseconds to run again",
                 self.interval


### PR DESCRIPTION
This change will still execute `is_successful` exactly once on the
`no_retry` path without executing the body of the `while` loop and keep
the same semantic for the `retry` path.